### PR TITLE
Raise a warning when importing `py2opsin` if Java is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p> 
 
 ## Installation
-`py2opsin` can be installed with `pip install py2opsin`. It has _zero_ Python dependencies (`OPSIN v2.7.0` is included in the PyPI package) and should work inside any environment running modern Python.
+`py2opsin` can be installed with `pip install py2opsin`. It has _zero_ Python dependencies (`OPSIN v2.7.0` is included in the PyPI package) and should work inside any environment running modern Python. Java 8+ is required to run OPSIN.
 
 Try a demo of `py2opsin` live on your browser (no installation required!): [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JacksonBurns/py2opsin/HEAD?labpath=examples%2Fpy2opsin_example.ipynb)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p> 
 
 ## Installation
-`py2opsin` can be installed with `pip install py2opsin`. It has _zero_ dependencies (`OPSIN v2.7.0` is included in the PyPI package) and should work inside any environment running modern Python.
+`py2opsin` can be installed with `pip install py2opsin`. It has _zero_ Python dependencies (`OPSIN v2.7.0` is included in the PyPI package) and should work inside any environment running modern Python.
 
 Try a demo of `py2opsin` live on your browser (no installation required!): [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/JacksonBurns/py2opsin/HEAD?labpath=examples%2Fpy2opsin_example.ipynb)
 

--- a/py2opsin/__init__.py
+++ b/py2opsin/__init__.py
@@ -1,3 +1,3 @@
 from .py2opsin import py2opsin
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -26,7 +26,7 @@ try:
 except Exception as e:
     warnings.warn(
         "Java may not be installed/accessible (java -version raised exception). "
-        "Java 8 or newer is required to use py2opsin. Original Error:\n" + e.stderr,
+        "Java 8 or newer is required to use py2opsin. Original Error:\n" + repr(e),
         category=RuntimeWarning,
     )
 

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -17,7 +17,7 @@ except ImportError:
 
 # check if java is installed
 try:
-    result = subprocess.run(["java"])
+    result = subprocess.run(["java", "-version"], stdout=subprocess.DEVNULL)
     result.check_returncode()
 except CalledProcessError as cpe:
     warnings.warn(

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -21,10 +21,10 @@ try:
     result = subprocess.run(["java", "--version"])
     result.check_returncode()
 except CalledProcessError as cpe:
-    raise RuntimeWarning(
-        "Java may not be installed/accessible (java --version raised exception)."
-        "Java 8 or newer is required to use py2opsin."
-    ) from cpe
+    warnings.warn(
+        "Java may not be installed/accessible (java --version raised exception). "
+        "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe
+    )
 
 
 def py2opsin(

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -37,7 +37,7 @@ def py2opsin(
         jar_fpath (str, optional): Filepath to OPSIN jar file. Defaults to "default", which causes py2opsin to use its included jar.
 
     Returns:
-        str: Species in requested format, or False if not found or an error occoured. List of strings if input is list.
+        str: Species in requested format, or False if not found or an error ocurred. List of strings if input is list.
     """
     if jar_fpath == "default":
         jar_fpath = pkg_fopen("opsin-cli-2.7.0-jar-with-dependencies.jar")
@@ -134,7 +134,7 @@ def py2opsin(
             )
 
     except Exception as e:
-        warnings.warn("Unexpected error occured! " + e)
+        warnings.warn("Unexpected error ocurred! " + e)
         return False
     finally:
         os.remove(temp_f)

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -16,17 +16,6 @@ except ImportError:
     pkg_fopen = lambda fname: resource_filename(__name__, fname)
 
 
-# warn users potentially missing java at import time
-try:
-    result = subprocess.run(["java", "--version"])
-    result.check_returncode()
-except CalledProcessError as cpe:
-    warnings.warn(
-        "Java may not be installed/accessible (java --version raised exception). "
-        "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe
-    )
-
-
 def py2opsin(
     chemical_name: Union[str, list],
     output_format: str = "SMILES",
@@ -51,6 +40,17 @@ def py2opsin(
     Returns:
         str: Species in requested format, or False if not found or an error ocurred. List of strings if input is list.
     """
+    # check if java is installed
+    try:
+        result = subprocess.run(["java", "--version"])
+        result.check_returncode()
+    except CalledProcessError as cpe:
+        warnings.warn(
+            "Java may not be installed/accessible (java --version raised exception). "
+            "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe
+        )
+
+    # path to OPSIN
     if jar_fpath == "default":
         jar_fpath = pkg_fopen("opsin-cli-2.7.0-jar-with-dependencies.jar")
 

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -22,7 +22,8 @@ try:
 except CalledProcessError as cpe:
     warnings.warn(
         "Java may not be installed/accessible (java --version raised exception). "
-        "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe.stderr
+        "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe.stderr,
+        category=RuntimeWarning,
     )
 
 

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 from difflib import get_close_matches
 from typing import Union
+from subprocess import CalledProcessError
 
 try:
     from importlib.resources import files
@@ -13,6 +14,17 @@ except ImportError:
     from pkg_resources import resource_filename
 
     pkg_fopen = lambda fname: resource_filename(__name__, fname)
+
+
+# warn users potentially missing java at import time
+try:
+    result = subprocess.run(["java", "--version"])
+    result.check_returncode()
+except CalledProcessError as cpe:
+    raise RuntimeWarning(
+        "Java may not be installed/accessible (java --version raised exception)."
+        "Java 8 or newer is required to use py2opsin."
+    ) from cpe
 
 
 def py2opsin(

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -37,7 +37,7 @@ def py2opsin(
         jar_fpath (str, optional): Filepath to OPSIN jar file. Defaults to "default", which causes py2opsin to use its included jar.
 
     Returns:
-        str: Species in requested format, or False if not found or an error occoured. List of strings if input is list.
+        str: Species in requested format, or False if not found or an error ocurred. List of strings if input is list.
     """
     if jar_fpath == "default":
         jar_fpath = pkg_fopen("opsin-cli-2.7.0-jar-with-dependencies.jar")
@@ -125,7 +125,7 @@ def py2opsin(
             )
 
     except Exception as e:
-        warnings.warn("Unexpected error occured! " + e)
+        warnings.warn("Unexpected error ocurred! " + e)
         return False
     finally:
         os.remove(temp_f)

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -21,7 +21,7 @@ try:
     result.check_returncode()
 except CalledProcessError as cpe:
     warnings.warn(
-        "Java may not be installed/accessible (java --version raised exception). "
+        "Java may not be installed/accessible (java -version raised exception). "
         "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe.stderr,
         category=RuntimeWarning,
     )

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -21,12 +21,12 @@ try:
         ["java", "-version"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        check=True,
     )
-    result.check_returncode()
-except CalledProcessError as cpe:
+except Exception as e:
     warnings.warn(
         "Java may not be installed/accessible (java -version raised exception). "
-        "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe.stderr,
+        "Java 8 or newer is required to use py2opsin. Original Error:\n" + e.stderr,
         category=RuntimeWarning,
     )
 

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -17,7 +17,11 @@ except ImportError:
 
 # check if java is installed
 try:
-    result = subprocess.run(["java", "-version"], stdout=subprocess.DEVNULL)
+    result = subprocess.run(
+        ["java", "-version"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     result.check_returncode()
 except CalledProcessError as cpe:
     warnings.warn(

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -15,6 +15,16 @@ except ImportError:
 
     pkg_fopen = lambda fname: resource_filename(__name__, fname)
 
+# check if java is installed
+try:
+    result = subprocess.run(["java"])
+    result.check_returncode()
+except CalledProcessError as cpe:
+    warnings.warn(
+        "Java may not be installed/accessible (java --version raised exception). "
+        "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe.stderr
+    )
+
 
 def py2opsin(
     chemical_name: Union[str, list],
@@ -40,18 +50,7 @@ def py2opsin(
     Returns:
         str: Species in requested format, or False if not found or an error ocurred. List of strings if input is list.
     """
-    # check if java is installed
-    try:
-        result = subprocess.run(["java", "--version"])
-        result.check_returncode()
-    except CalledProcessError as cpe:
-        warnings.warn(
-            "Java may not be installed/accessible (java --version raised exception). "
-            "Java 8 or newer is required to use py2opsin. Original Error:\n"
-            + cpe.stderr
-        )
-
-    # path to OPSIN
+    # path to OPSIN jar
     if jar_fpath == "default":
         jar_fpath = pkg_fopen("opsin-cli-2.7.0-jar-with-dependencies.jar")
 

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -47,7 +47,8 @@ def py2opsin(
     except CalledProcessError as cpe:
         warnings.warn(
             "Java may not be installed/accessible (java --version raised exception). "
-            "Java 8 or newer is required to use py2opsin. Original Error:\n" + cpe
+            "Java 8 or newer is required to use py2opsin. Original Error:\n"
+            + cpe.stderr
         )
 
     # path to OPSIN

--- a/test/test_py2opsin.py
+++ b/test/test_py2opsin.py
@@ -186,8 +186,6 @@ class Test_py2opsin(unittest.TestCase):
         smiles_list = py2opsin(list_with_errors)
         self.assertEqual(smiles_list, correct_list)
 
-    #     pass
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #10 - its not obvious to those looking only at the py2opsin page that Java is required.