### PR TITLE
Add helpful warnings when OPSIN fails to parse

### DIFF
--- a/py2opsin/__init__.py
+++ b/py2opsin/__init__.py
@@ -1,3 +1,3 @@
 from .py2opsin import py2opsin
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -104,9 +104,18 @@ def py2opsin(
     # do the call
     result = subprocess.run(
         arg_list,
-        stderr=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
+
+    # warn user if any of the inputs could not be parsed
+    if result.stderr:
+        err_str = result.stderr.decode(encoding=sys.stderr.encoding)
+        warnings.warn(
+            "OPSIN raised the following error(s) while parsing:\n > "
+            + err_str.replace("\n", "\n > ", err_str.count("\n") - 1),
+            RuntimeWarning,
+        )
 
     # parse and return the result
     try:

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -112,8 +112,8 @@ def py2opsin(
     if result.stderr:
         err_str = result.stderr.decode(encoding=sys.stderr.encoding)
         warnings.warn(
-            "OPSIN raised the following error(s) while parsing:\n > "
-            + err_str.replace("\n", "\n > ", err_str.count("\n") - 1),
+            "OPSIN raised the following error(s) while parsing:"
+            "\n > " + err_str.replace("\n", "\n > ", err_str.count("\n") - 1),
             RuntimeWarning,
         )
 

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -391,6 +391,7 @@ class Test_py2opsin_performance(unittest.TestCase):
             "ditechnetium decacarbonyl",
         ]
 
+    @unittest.skipIf(os.path.exists(".no_perf_test"), "file .no_perf_test was found")
     def test_performance(self):
         """
         Test performance relative to pubchempy

--- a/test/test_py2opsin.py
+++ b/test/test_py2opsin.py
@@ -78,6 +78,11 @@ class Test_py2opsin(unittest.TestCase):
             )
         ]
 
+    def test_helpful_warning(self):
+        """Raise warnings when input cannot be parsed."""
+        with self.assertWarns(RuntimeWarning):
+            py2opsin(["Methane is an IUPAC Name", "I Have to Fly Planes"])
+
     def test_invalid_output_spec(self):
         """Invalid output specification should raise a runtime error."""
         with self.assertRaises(RuntimeError):
@@ -183,10 +188,9 @@ class Test_py2opsin(unittest.TestCase):
         """
         list_with_errors = ["methane", "ethane", "blah", "water"]
         correct_list = ["C", "CC", "", "O"]
-        smiles_list = py2opsin(list_with_errors)
+        with self.assertWarns(RuntimeWarning):
+            smiles_list = py2opsin(list_with_errors)
         self.assertEqual(smiles_list, correct_list)
-
-    #     pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds helpful warning messages when parsing fails in OPSIN by capturing stderr (rather than ignoring it) and then formatting it into a nice Python error which can be either acted upon or ignored as they are now (with a catch warnings block).

Resolves #12 