### PR TITLE
remove 3.7 from ci - deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
CI is failing because Python 3.7 is no longer available on Mac runners - it's deprecated anyway, so this PR just removes it from the CI (though `py2opsin` still supports it).