### PR TITLE
feat: Add temporary-file-path argument for multi-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ smiles_str = "CC"
     allow_bad_stereo = False,
     wildcard_radicals = False,
     jar_fpath = "/path/to/opsin.jar",
+    tmp_fpath = "py2opsin_temp_input.txt",
 )
 ```
 
-The result is returned as a Python string, or False if an unexpected error occurs when calling OPSIN. If a list of IUPAC names is provided, a list is returned. It is __highly__ reccomended to use `py2opsin` in this manner if you need to resolve any more than a couple names -- the performance cost of running `OPSIN` from Python one name at a time is significant (~5 seconds/molecule individually, milliseconds otherwise).
+The result is returned as a Python string, or False if an unexpected error occurs when calling OPSIN. If a list of IUPAC names is provided, a list is returned. It is __highly__ recommended to use `py2opsin` in this manner if you need to resolve any more than a couple names -- the performance cost of running `OPSIN` from Python one name at a time is significant (~5 seconds/molecule individually, milliseconds otherwise).
 
 Arguments:
  - chemical_name (str): IUPAC name of chemical as a Python string, or a list of strings.
@@ -51,7 +52,10 @@ Arguments:
  - allow_bad_stereo (bool, optional): Allow OPSIN to ignore uninterpreatable stereochem. Defaults to False.
  - wildcard_radicals (bool, optional): Output radicals as wildcards. Defaults to False.
  - jar_fpath (str, optional): Filepath to OPSIN jar file. Defaults to "opsin-cli.jar" which is distributed with py2opsin.
+ - tmp_fpath (str, optional): tmp_fpath (str, optional): Name for temporary file used for calling OPSIN. Defaults to "py2opsin_temp_input.txt". When multiprocessing, set this to a unique name for each process.
 
+> [!TIP]
+> `OPSIN` will already parallelize itself by creating multiple threads! Be wary when using `py2opsin` with multiprocessing to avoid spawning too many processes.
 
 ## Massive speedup from `pubchempy` for batch translations
 `py2opsin` runs locally and is smaller in scope in what it provides, which makes it __dramatically__ faster at resolving identifiers. In the code block below, the call to `py2opsin` will execute faster than an equivalent call to `pubchempy`:

--- a/py2opsin/__init__.py
+++ b/py2opsin/__init__.py
@@ -1,3 +1,3 @@
 from .py2opsin import py2opsin
 
-__version__ = "1.0.6"
+__version__ = "1.1.0"

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -53,6 +53,7 @@ def py2opsin(
     allow_bad_stereo: bool = False,
     wildcard_radicals: bool = False,
     jar_fpath: str = "default",
+    tmp_fpath: str = "py2opsin_temp_input.txt",
 ) -> str:
     """Simple passthrough to opsin, returning results as Python strings.
 
@@ -112,15 +113,14 @@ def py2opsin(
         )
 
     # write the input to a text file
-    temp_f = "py2opsin_temp_input.txt"
-    with open(temp_f, "w") as file:
+    with open(tmp_fpath, "w") as file:
         if type(chemical_name) is str:
             file.write(chemical_name)
         else:
             file.writelines("\n".join(chemical_name) + "\n")
 
     # add the temporary file to the args
-    arg_list.append(temp_f)
+    arg_list.append(tmp_fpath)
 
     # grab the optional boolean flags
     if allow_acid:
@@ -168,4 +168,4 @@ def py2opsin(
         warnings.warn("Unexpected error ocurred! " + e)
         return False
     finally:
-        os.remove(temp_f)
+        os.remove(tmp_fpath)

--- a/py2opsin/py2opsin.py
+++ b/py2opsin/py2opsin.py
@@ -66,6 +66,8 @@ def py2opsin(
         allow_bad_stereo (bool, optional): Allow OPSIN to ignore uninterpreatable stereochem. Defaults to False.
         wildcard_radicals (bool, optional): Output radicals as wildcards. Defaults to False.
         jar_fpath (str, optional): Filepath to OPSIN jar file. Defaults to "default", which causes py2opsin to use its included jar.
+        tmp_fpath (str, optional): Name for temporary file used for calling OPSIN. Defaults to "py2opsin_temp_input.txt".
+                                   When multiprocessing, set this to a unique name for each process.
 
     Returns:
         str: Species in requested format, or False if not found or an error ocurred. List of strings if input is list.

--- a/test/test_py2opsin.py
+++ b/test/test_py2opsin.py
@@ -1,8 +1,14 @@
 import os
+import multiprocessing
 import sys
 import unittest
 
 from py2opsin import py2opsin
+
+
+# multiprocessing test function
+def _f(b):
+    return py2opsin(b[0], tmp_fpath=f"tmp_{b[1]}.txt")
 
 
 class Test_py2opsin(unittest.TestCase):
@@ -96,6 +102,12 @@ class Test_py2opsin(unittest.TestCase):
             str(helpful_error.exception),
             "Output format SMOLES is invalid. Did you mean 'SMILES'?",
         )
+
+    def test_multiprocessing(self):
+        """py2opsin should safely work when run with multiprocessing"""
+        with multiprocessing.Pool(2) as pool:
+            res = pool.map(_f, [("methanol", 0), ("ethanol", 1)])
+        self.assertEqual(res, ["CO", "C(C)O"])
 
     def test_name_to_smiles(self):
         """


### PR DESCRIPTION
Thank you for the great repo!

I found that using a single predefined temp-file-path may cause error because of race condition. This patch simply resolves the issue by adding option (`tmp_fpath`).

```python
import os
from multiprocessing import Process, Queue
from py2opsin import py2opsin
import tqdm


def worker(tmp_fpath, q1, q2):
    while True:
        data = q1.get()

        if data is None:
            break

        smiles = py2opsin(data, tmp_fpath=tmp_fpath)
        q2.put(smiles)


if __name__ == "__main__":
    n_processes = 4
    os.makedirs("tmp", exist_ok=True)
    tmp_fpaths = [f"tmp/{i}.txt" for i in range(n_processes)]

    q1 = Queue()
    q2 = Queue()

    processes = [Process(target=worker, args=(tmp_fpaths[i], q1, q2)) for i in range(n_processes)]
    [p.start() for p in processes]

    for i in tqdm.tqdm(range(100)):
        q1.put("2,4,6-trinitrotoluene")

    for _ in tqdm.tqdm(range(100)):
        smiles = q2.get()
        assert smiles == "[N+](=O)([O-])C1=C(C)C(=CC(=C1)[N+](=O)[O-])[N+](=O)[O-]", smiles

    for _ in range(n_processes):
        q1.put(None)

    [p.join() for p in processes]
```