### PR TITLE
GitHub Actions Maintainence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           timeout_minutes: 15
           shell: bash
           command: |
-            mamba run -n temp coverage run --source=. --omit=py2opsin/__init__.py,setup.py,test/* -m unittest discover
+            mamba run -n test coverage run --source=. --omit=py2opsin/__init__.py,setup.py,test/* -m unittest discover
       - name: Show Coverage
         run: |
           coverage report -m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,13 @@ jobs:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} Subtest
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@main
+      - name: Setup Miniforge Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          environment-name: temp
-          condarc: |
-            channels:
-              - defaults
-              - conda-forge
-            channel_priority: flexible
-          create-args: |
-            python=${{ matrix.python-version }}
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          python-version: ${{ matrix.python-version }}
+          use-mamba: true
       - name: Install Dependencies
         run: |
           python -m pip install .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check Formatting Errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           python -m pip install pycodestyle autopep8
@@ -41,7 +41,7 @@ jobs:
         shell: bash -el {0}
     name: ${{ matrix.os }} Python ${{ matrix.python-version }} Subtest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Miniforge Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -84,7 +84,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && github.repository == 'JacksonBurns/py2opsin'}}
     needs: ci-report-status
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           timeout_minutes: 15
           shell: bash
           command: |
-            micromamba run -n temp coverage run --source=. --omit=py2opsin/__init__.py,setup.py,test/* -m unittest discover
+            mamba run -n temp coverage run --source=. --omit=py2opsin/__init__.py,setup.py,test/* -m unittest discover
       - name: Show Coverage
         run: |
           coverage report -m


### PR DESCRIPTION
 - fix failing CI because of deprecated micromamba by switching to miniforge
 - change checkout to v4