### PR TITLE
Skip Network-Related Performance Tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
         run: |
           python -m pip install .[dev]
           python -m pip install coverage
+      - name: Skip Network-Related Performance Tests on Windows
+        if: runner.os == 'windows'
+        run: touch .no_perf_test
       - name: Run Tests
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Skip Network-Related Performance Tests on Windows
         if: runner.os == 'windows'
         run: touch test/.no_perf_test
+      - name: DROP ME run tests outside of retry afor stack trace
+        run: coverage run --source=. --omit=py2opsin/__init__.py,setup.py,test/* -m unittest discover
       - name: Run Tests
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python -m pip install coverage
       - name: Skip Network-Related Performance Tests on Windows
         if: runner.os == 'windows'
-        run: touch .no_perf_test
+        run: touch test/.no_perf_test
       - name: Run Tests
         uses: nick-fields/retry@v3
         with:


### PR DESCRIPTION
This step in the CI fails on Windows all the time because of random network drops on the GitHub actions runners - just going to skip them.